### PR TITLE
feat(ci,config): add dev/prod env URLs and improve deploy flow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,31 +3,65 @@ name: Deploy to GCP
 on:
   push:
     branches:
+      - develop
       - main
     tags:
       - "v*.*.*"
 
 jobs:
-  deploy:
+  init:
     runs-on: ubuntu-latest
-    environment: production
+    outputs:
+      environment: ${{ steps.set_env.outputs.environment }}
+      version: ${{ steps.set_env.outputs.version }}
+      should_deploy: ${{ steps.set_env.outputs.should_deploy }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract version from tag or branch
-        id: get_version
+      - name: Determine environment and version
+        id: set_env
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "version=latest" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "Deploying to dev environment: latest"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "environment=production" >> $GITHUB_OUTPUT
+            echo "version=latest" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "Deploying to production environment: latest"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # Verify tag is on main branch
+            git fetch origin main
+            TAG_COMMIT=$(git rev-parse HEAD)
+            if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+              echo "Error: Tag must be created from main branch"
+              echo "should_deploy=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
             VERSION=${GITHUB_REF#refs/tags/}
+            echo "environment=production" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "Deploying to production environment: ${VERSION}"
           else
-            VERSION="latest"
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+            echo "No deployment needed for this ref"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Deploying version: ${VERSION}"
+
+  deploy:
+    needs: init
+    if: needs.init.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ needs.init.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Deploy to GCP VM via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.VM_HOST }}
           username: deploy
@@ -35,10 +69,10 @@ jobs:
           port: 22
           script: |
             cd /home/deploy/api-server
-            ./deploy.sh ${{ steps.get_version.outputs.version }}
+            ./deploy.sh ${{ needs.init.outputs.version }}
 
       - name: Verify deployment
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.VM_HOST }}
           username: deploy

--- a/guanfu_backend/.env.example
+++ b/guanfu_backend/.env.example
@@ -65,5 +65,6 @@ INSTANCE_CONNECTION_NAME=
 # 生產環境設定（選用）
 # ----------------------------------------------------------------------------
 
-# 生產環境伺服器 URL（預設值已在 config.py 中設定，可選）
-# PROD_SERVER_URL=https://guangfu250923.pttapp.cc
+# 測試/生產環境伺服器 URL（預設值已在 config.py 中設定，可選）
+# PROD_SERVER_URL=https://api.gf250923.org
+# DEV_SERVER_URL=https://uat-api.gf250923.org

--- a/guanfu_backend/src/config.py
+++ b/guanfu_backend/src/config.py
@@ -24,7 +24,8 @@ class Settings(BaseSettings):
     INSTANCE_CONNECTION_NAME: str = ""
 
     # PROD_SERVER_URL 可以有預設值，因為它不是敏感資訊
-    PROD_SERVER_URL: str = "https://uat-api.gf250923.org"
+    PROD_SERVER_URL: str = "https://api.gf250923.org"
+    DEV_SERVER_URL: str = "https://uat-api.gf250923.org"
 
     # LAN_SERVER_URL 如果在本地的 LAN 主機做為測試環境，可使用此 URL
     LAN_SERVER_URL: str = "http://192.168.1.107"

--- a/guanfu_backend/src/main.py
+++ b/guanfu_backend/src/main.py
@@ -38,10 +38,21 @@ async def lifespan(app: FastAPI):
 
 # --- 根據環境動態設定 Swagger UI 的伺服器 URL ---
 servers = [
-    {"url": f"http://localhost:{settings.SERVER_PORT}", "description": "本地開發 (Dev)"},
-    {"url": f"{settings.LAN_SERVER_URL}:{settings.SERVER_PORT}", "description": "LAN 主機環境 (Test On LAN)"},
+    {
+        "url": f"http://localhost:{settings.SERVER_PORT}",
+        "description": "本地開發 (Local)",
+    },
+    {
+        "url": f"{settings.LAN_SERVER_URL}:{settings.SERVER_PORT}",
+        "description": "LAN 主機環境 (Test On LAN)",
+    },
 ]
-if settings.ENVIRONMENT == "prod":
+if settings.ENVIRONMENT == "dev":
+    servers.insert(
+        0, {"url": settings.DEV_SERVER_URL, "description": "測試環境 (development)"}
+    )
+
+elif settings.ENVIRONMENT == "prod":
     servers.insert(
         0, {"url": settings.PROD_SERVER_URL, "description": "線上服務 (Production)"}
     )


### PR DESCRIPTION
## 概述

新增開發環境 (dev) 支援並改進部署流程，實現開發環境與正式環境的分離部署。

## 變更內容

### 🚀 CI/CD 改進

- **新增開發環境自動部署**：`develop` 分支推送時自動部署到開發環境
- **環境分離**：新增 `init` job 來動態決定部署環境 (dev/production) 和版本
- **版本管理改進**：
  - `develop` → dev 環境 (latest)
  - `main` → production 環境 (latest)
  - tags → production 環境 (指定版本)
- **Tag 安全性檢查**：確保 tag 只能從 main 分支建立
- **升級依賴**：更新 `appleboy/ssh-action` 從 v1.0.3 到 v1.2.2

### ⚙️ 環境配置更新

- **URL 配置調整**：
  - `PROD_SERVER_URL`: `https://api.gf250923.org` (正式環境)
  - `DEV_SERVER_URL`: `https://uat-api.gf250923.org` (開發環境)
- **Swagger UI 改進**：根據 `ENVIRONMENT` 變數動態顯示對應環境的伺服器 URL

### 📝 文件更新

- 更新 `.env.example` 說明，新增開發環境 URL 配置範例

## 測試計畫

- [ ] 驗證 `develop` 分支推送觸發開發環境部署
- [ ] 驗證 `main` 分支推送觸發正式環境部署
- [ ] 驗證 tag 建立觸發正式環境部署 (指定版本)
- [ ] 驗證非 main 分支的 tag 會被阻止部署
- [ ] 確認 Swagger UI 在不同環境下顯示正確的伺服器 URL

## 影響範圍

- CI/CD pipeline
- 環境配置
- API 文件介面

## 部署說明

此變更需要確保：
1. GitHub Secrets 中已配置 `VM_HOST` 和 `VM_SSH_KEY`
2. 開發環境與正式環境的部署腳本 (`deploy.sh`) 已就緒
3. 兩個環境的伺服器 URL 已正確設定