### PR TITLE
[Add] api key in PATCH api

### DIFF
--- a/guanfu_backend/.env.example
+++ b/guanfu_backend/.env.example
@@ -20,6 +20,9 @@ APP_TITLE=花蓮光復救災平台 API
 # 應用程式埠號（Docker 容器內使用）
 PORT=8080
 
+# PATCH and DELETE API KEY LIST
+ALLOW_MODIFY_API_KEY_LIST=key1,key2,key3
+
 # 生產環境伺服器 URL（預設值已在 config.py 中設定，可選）
 # PROD_SERVER_URL=https://guangfu250923.pttapp.cc
 

--- a/guanfu_backend/docker-compose.yaml
+++ b/guanfu_backend/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       ENVIRONMENT: ${ENVIRONMENT}
       APP_TITLE: ${APP_TITLE}
+      ALLOW_MODIFY_API_KEY_LIST: ${ALLOW_MODIFY_API_KEY_LIST}
     volumes:
       - .env:/app/src/.env:ro
     ports:

--- a/guanfu_backend/src/api_key.py
+++ b/guanfu_backend/src/api_key.py
@@ -1,0 +1,62 @@
+from fastapi import HTTPException, Security
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from starlette import status
+from starlette.requests import Request
+
+from .config import settings
+
+API_KEY_HEADER = "x-api-key"
+AUTHORIZATION_HEADER = "authorization"
+BEARER_PREFIX = "bearer "
+
+
+def _parse_allowlist(raw_values: str) -> set[str]:
+    """Turn a comma-separated allowlist into a set of keys."""
+    return {item.strip() for item in raw_values.split(",") if item.strip()}
+
+
+def _allowed_keys() -> set[str]:
+    return _parse_allowlist(settings.ALLOW_MODIFY_API_KEY_LIST)
+
+
+api_key_header_scheme = APIKeyHeader(name="X-Api-Key", auto_error=False)
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def extract_api_key(request: Request) -> str:
+    """Return the provided API key from either X-Api-Key or Authorization headers."""
+    key = request.headers.get(API_KEY_HEADER, "").strip()
+    if key:
+        return key
+    authorization = request.headers.get(AUTHORIZATION_HEADER, "")
+    if authorization.lower().startswith(BEARER_PREFIX):
+        return authorization[len(BEARER_PREFIX) :].strip()
+    return ""
+
+
+async def require_modify_api_key(
+    request: Request,
+    _api_key_from_header: str | None = Security(api_key_header_scheme),
+    _bearer_credentials: HTTPAuthorizationCredentials | None = Security(bearer_scheme),
+) -> str:
+    allowed = _allowed_keys()
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Modification not allowed",
+        )
+
+    key = extract_api_key(request)
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Modification not allowed",
+        )
+
+    if key not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid API key",
+        )
+
+    return key

--- a/guanfu_backend/src/config.py
+++ b/guanfu_backend/src/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     # LAN_SERVER_URL 如果在本地的 LAN 主機做為測試環境，可使用此 URL
     LAN_SERVER_URL: str = "http://192.168.1.107"
     SERVER_PORT: str = "8080"
-
+    ALLOW_MODIFY_API_KEY_LIST: str = ""
 
 # 建立一個全域的 settings 實例供整個專案引用
 settings = Settings()

--- a/guanfu_backend/src/routers/accommodations.py
+++ b/guanfu_backend/src/routers/accommodations.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import AccommodationVacancyEnum, AccommodationStatusEnum
 
 router = APIRouter(
@@ -55,7 +56,12 @@ def get_accommodation(id: str, db: Session = Depends(get_db)):
     return db_accommodation
 
 
-@router.patch("/{id}", response_model=schemas.Accommodation, summary="更新特定庇護所資料")
+@router.patch(
+    "/{id}",
+    response_model=schemas.Accommodation,
+    summary="更新特定庇護所資料",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_accommodation(
         id: str, accommodation_in: schemas.AccommodationPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/human_resources.py
+++ b/guanfu_backend/src/routers/human_resources.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional, Literal
 from .. import crud, models, schemas
 from ..database import get_db
 from ..enum_serializer import HumanResourceRoleStatusEnum, HumanResourceRoleTypeEnum, HumanResourceStatusEnum
 from ..pin_related import generate_pin
+from ..api_key import require_modify_api_key
 
 router = APIRouter(
     prefix="/human_resources",
@@ -76,7 +77,12 @@ def get_human_resource(id: str, db: Session = Depends(get_db)):
     return db_resource
 
 
-@router.patch("/{id}", response_model=schemas.HumanResource, summary="更新特定人力需求")
+@router.patch(
+    "/{id}",
+    response_model=schemas.HumanResource,
+    summary="更新特定人力需求",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_human_resource(
         id: str, resource_in: schemas.HumanResourcePatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/medical_stations.py
+++ b/guanfu_backend/src/routers/medical_stations.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import MedicalStationTypeEnum, MedicalStationStatusEnum
 
 router = APIRouter(
@@ -50,7 +51,12 @@ def get_medical_station(id: str, db: Session = Depends(get_db)):
     return db_station
 
 
-@router.patch("/{id}", response_model=schemas.MedicalStation, summary="更新特定醫療站")
+@router.patch(
+    "/{id}",
+    response_model=schemas.MedicalStation,
+    summary="更新特定醫療站",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_medical_station(
         id: str, station_in: schemas.MedicalStationPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/mental_health_resources.py
+++ b/guanfu_backend/src/routers/mental_health_resources.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import MentalHealthDurationEnum, MentalHealthFormatEnum, MentalHealthResourceStatusEnum
 
 router = APIRouter(
@@ -55,7 +56,12 @@ def get_mental_health_resource(id: str, db: Session = Depends(get_db)):
     return db_resource
 
 
-@router.patch("/{id}", response_model=schemas.MentalHealthResource, summary="更新特定心理健康資源")
+@router.patch(
+    "/{id}",
+    response_model=schemas.MentalHealthResource,
+    summary="更新特定心理健康資源",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_mental_health_resource(
         id: str, resource_in: schemas.MentalHealthResourcePatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/reports.py
+++ b/guanfu_backend/src/routers/reports.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 
 router = APIRouter(
     prefix="/reports",
@@ -48,7 +49,12 @@ def get_report(id: str, db: Session = Depends(get_db)):
     return db_report
 
 
-@router.patch("/{id}", response_model=schemas.Report, summary="更新特定回報事件")
+@router.patch(
+    "/{id}",
+    response_model=schemas.Report,
+    summary="更新特定回報事件",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_report(
         id: str, report_in: schemas.ReportPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/restrooms.py
+++ b/guanfu_backend/src/routers/restrooms.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import RestroomFacilityTypeEnum, RestroomStatusEnum
 
 router = APIRouter(
@@ -59,7 +60,12 @@ def get_restroom(id: str, db: Session = Depends(get_db)):
     return db_restroom
 
 
-@router.patch("/{id}", response_model=schemas.Restroom, summary="更新特定廁所點")
+@router.patch(
+    "/{id}",
+    response_model=schemas.Restroom,
+    summary="更新特定廁所點",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_restroom(
         id: str, restroom_in: schemas.RestroomPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/shelters.py
+++ b/guanfu_backend/src/routers/shelters.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 from typing import Optional
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..schemas import ShelterStatusEnum
 router = APIRouter(
     prefix="/shelters",
@@ -48,7 +49,12 @@ def get_shelter(id: str, db: Session = Depends(get_db)):
     return db_shelter
 
 
-@router.patch("/{id}", response_model=schemas.Shelter, summary="更新特定庇護所")
+@router.patch(
+    "/{id}",
+    response_model=schemas.Shelter,
+    summary="更新特定庇護所",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_shelter(
         id: str, shelter_in: schemas.ShelterPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/shower_stations.py
+++ b/guanfu_backend/src/routers/shower_stations.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import ShowerFacilityTypeEnum, ShowerStationStatusEnum
 
 router = APIRouter(
@@ -59,7 +60,12 @@ def get_shower_station(id: str, db: Session = Depends(get_db)):
     return db_station
 
 
-@router.patch("/{id}", response_model=schemas.ShowerStation, summary="更新特定洗澡點")
+@router.patch(
+    "/{id}",
+    response_model=schemas.ShowerStation,
+    summary="更新特定洗澡點",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_shower_station(
         id: str, station_in: schemas.ShowerStationPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/supplies.py
+++ b/guanfu_backend/src/routers/supplies.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session, joinedload
 from typing import Optional, List, Literal
 from .. import crud, models, schemas
 from ..crud import get_full_supply
 from ..database import get_db
+from ..api_key import require_modify_api_key
 
 router = APIRouter(
     prefix="/supplies",
@@ -62,7 +63,13 @@ def create_supply(
 
 
 # 在 patch_supply 禁止更新已全部到貨的供應單
-@router.patch("/{id}", response_model=schemas.Supply, status_code=200, summary="更新供應單")
+@router.patch(
+    "/{id}",
+    response_model=schemas.Supply,
+    status_code=200,
+    summary="更新供應單",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_supply(
         id: str, supply_in: schemas.SupplyPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/supply_items.py
+++ b/guanfu_backend/src/routers/supply_items.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 from ..enum_serializer import SupplyItemTypeEnum
 
 router = APIRouter(
@@ -52,7 +53,13 @@ def create_supply_item(
     return crud.create(db, models.SupplyItem, obj_in=schemas.SupplyItemCreate(**supply_item))
 
 
-@router.patch("/{id}", response_model=schemas.SupplyItem, status_code=200, summary="更新特定供應單物資項目")
+@router.patch(
+    "/{id}",
+    response_model=schemas.SupplyItem,
+    status_code=200,
+    summary="更新特定供應單物資項目",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_supply_item(
         id: str, item_in: schemas.SupplyItemPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/volunteer_organizations.py
+++ b/guanfu_backend/src/routers/volunteer_organizations.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 
 router = APIRouter(
     prefix="/volunteer_organizations",
@@ -46,7 +47,12 @@ def get_volunteer_org(id: str, db: Session = Depends(get_db)):
     return db_org
 
 
-@router.patch("/{id}", response_model=schemas.VolunteerOrganization, summary="更新特定志工招募單位")
+@router.patch(
+    "/{id}",
+    response_model=schemas.VolunteerOrganization,
+    summary="更新特定志工招募單位",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_volunteer_org(
         id: str, org_in: schemas.VolunteerOrgPatch, db: Session = Depends(get_db)
 ):

--- a/guanfu_backend/src/routers/water_refill_stations.py
+++ b/guanfu_backend/src/routers/water_refill_stations.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from sqlalchemy.orm import Session
 
 from .. import crud, models, schemas
 from ..database import get_db
+from ..api_key import require_modify_api_key
 
 router = APIRouter(
     prefix="/water_refill_stations",
@@ -58,7 +59,12 @@ def get_water_refill_station(id: str, db: Session = Depends(get_db)):
     return db_station
 
 
-@router.patch("/{id}", response_model=schemas.WaterRefillStation, summary="更新特定飲用水補給站")
+@router.patch(
+    "/{id}",
+    response_model=schemas.WaterRefillStation,
+    summary="更新特定飲用水補給站",
+    dependencies=[Security(require_modify_api_key)],
+)
 def patch_water_refill_station(
         id: str, station_in: schemas.WaterRefillStationPatch, db: Session = Depends(get_db)
 ):


### PR DESCRIPTION
## 概述

新增api key在每支PATCH api上(目前沒有delete api)
- 支持兩種 header 格式
X-API-Key: <your-api-key>
Authorization: Bearer <your-api-key>

- 在每支PATCH api上掛上dependencies, 不採用middleware寫法, 讓swagger上也可以使用
(router folder內檔案的改動都相同, 加上 `dependencies=[Security(require_modify_api_key)],`)


## 變更內容

1. all PATCH api
2. add api_key.py


## 測試方式

local test可在swagger上確認沒給key會有正確error

## 相關 Issue

https://www.notion.so/PATCH-DELETE-API-Key-286f457cb42880fc9208eacc3b820c5b?source=copy_link

Closes #
Refs #

## 截圖

<!-- 如果有 UI 變更，請提供截圖 -->

## Checklist

- [ ] 程式碼遵循專案規範
- [ ] 已新增/更新必要的測試
- [ ] 已更新相關文件
- [ ] CI 檢查全部通過
- [ ] 已在本地測試過
- [ ] Commit 訊息符合 Conventional Commits 規範
