### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,6 @@
 name: Deploy to GCP
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GuangFuHero/api-server/security/code-scanning/3](https://github.com/GuangFuHero/api-server/security/code-scanning/3)

To fix the problem, we need to add an explicit `permissions:` block to the workflow. As no step in the workflow requires write access to repository contents, or other elevated permissions, we can set minimal permissions. The most appropriate is `contents: read`, placed right after the workflow `name:` and before the `jobs:` block in `.github/workflows/cicd.yaml`. This will restrict the GITHUB_TOKEN in all jobs to read-only access to repository contents, improving security by adhering to the principle of least privilege. No imports or further code changes are required; the fix consists simply of inserting a short YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
