### PR TITLE
chore: allow map CORS for dev environment

### DIFF
--- a/guanfu_backend/nginx/conf.d/default.conf
+++ b/guanfu_backend/nginx/conf.d/default.conf
@@ -40,6 +40,11 @@ server {
         set $cors_origin $http_origin;
     }
 
+    # Allow map site dev environment
+    if ($http_origin = "https://guangfu-hero-web-git-dev-sams-projects-a10c479a.vercel.app") {
+        set $cors_origin $http_origin;
+    }
+
     # -------------------------
     # Main Proxy
     # -------------------------


### PR DESCRIPTION
## Summary
- Add CORS support for the map site development environment hosted on Vercel

## Changes
- Updated nginx configuration to allow CORS requests from `https://guangfu-hero-web-git-dev-sams-projects-a10c479a.vercel.app`
- This enables the development environment of the map application to communicate with the API server

## Test plan
- [x] Verify CORS headers are correctly set for requests from the dev map site
- [ ] Confirm existing CORS configurations continue to work
- [ ] Test that unauthorized origins are still blocked

## Verification
Original (use production as example)
<img width="1447" height="365" alt="image" src="https://github.com/user-attachments/assets/06a9438a-9de9-470b-9860-46e558227f89" />

Current:
<img width="1450" height="460" alt="image" src="https://github.com/user-attachments/assets/f38e62f5-1a71-4411-a999-90814e1fad94" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)