### PR TITLE
add method to send discord channel when user send POST request

### DIFF
--- a/docs/discord-webhook-guide.md
+++ b/docs/discord-webhook-guide.md
@@ -1,0 +1,103 @@
+# Developer Guide: Discord Webhook Integration
+
+This guide explains how to use the automated Discord notification feature in this project.
+
+## 1. Introduction
+
+To improve visibility on data creation, the system is integrated with a Discord webhook. This feature automatically sends a notification to a designated Discord channel whenever new data is created via most `POST` APIs.
+
+This is achieved using a global middleware that intercepts outgoing requests.
+
+## 2. How to Use
+
+There are two ways to trigger the webhook: automatically (for most cases) and manually (for special cases).
+
+### Method 1: Automatic Triggering (Default Behavior)
+
+For any developer adding a new `POST` endpoint to the API, this functionality is **enabled by default**. You do not need to write any extra code to activate it.
+
+The `DiscordWebhookMiddleware` in `src/main.py` automatically intercepts any `POST` request with a JSON body and sends its content to the Discord channel.
+
+**Example:**
+
+If you create a new router for `products` like this, it will automatically trigger the webhook:
+
+```python
+# src/routers/products.py
+
+@router.post("/")
+def create_product(product: ProductCreate):
+    # ... your logic to save the product ...
+    return new_product
+```
+
+#### How to Opt-Out
+
+If you have a specific `POST` API that should **not** trigger a Discord notification, you can exclude it:
+
+1.  Open `src/main.py`.
+2.  Find the `DiscordWebhookMiddleware` class.
+3.  Add your endpoint's path to the `excluded_paths` list.
+
+```python
+# src/main.py
+
+class DiscordWebhookMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        # ...
+        # Add the path you want to exclude here
+        excluded_paths = ["/line/callback", "/your/excluded/path"]
+        if request.url.path in excluded_paths:
+            return await call_next(request)
+        # ...
+```
+
+### Method 2: Manual Triggering (Advanced)
+
+If you want to send a notification from a non-`POST` request (e.g., a `GET` or `PATCH`), or if you want to send a custom-formatted message from a background task, you can call the webhook service function directly.
+
+**Steps:**
+
+1.  **Import the function** at the top of your file:
+
+    ```python
+    from ..services.discord_webhook import send_to_discord
+    ```
+
+2.  **Call the function** with `await` and provide a Python dictionary (`dict`) as the payload. The dictionary will be converted to JSON and sent.
+
+    ```python
+    # Example: Sending a custom notification from a GET endpoint
+
+    @router.get("/{item_id}")
+    async def get_special_item(item_id: str):
+        item = db.get(item_id)
+
+        # Manually trigger a custom notification
+        await send_to_discord({
+            "message": "A high-priority item was accessed.",
+            "item_id": item_id,
+            "timestamp": datetime.now().isoformat()
+        })
+
+        return item
+    ```
+
+## 3. Testing the Webhook
+
+A dedicated test endpoint exists to verify that the connection to Discord is working correctly.
+
+-   **Endpoint**: `POST /test/discord`
+
+This endpoint directly calls the `send_to_discord` service.
+
+You can use the following `curl` command to test it:
+
+```bash
+curl -X POST http://localhost:8000/test/discord -H "Content-Type: application/json" -d '{
+  "user": "test-developer",
+  "message": "Verifying the Discord webhook connection."
+}'
+```
+
+If the request is successful, a formatted message with the JSON payload will appear in the designated Discord channel.

--- a/guanfu_backend/src/config.py
+++ b/guanfu_backend/src/config.py
@@ -38,6 +38,9 @@ class Settings(BaseSettings):
     LINE_REDIRECT_URI: str
     LINE_SCOPES: str = "profile openid email"
 
+    # Discord Webhook
+    DISCORD_WEBHOOK_URL: str = ""
+
 
 # 建立一個全域的 settings 實例供整個專案引用
 settings = Settings()

--- a/guanfu_backend/src/services/discord_webhook.py
+++ b/guanfu_backend/src/services/discord_webhook.py
@@ -1,0 +1,32 @@
+import httpx
+from ..config import settings
+import json
+
+async def send_to_discord(payload: dict):
+    """
+    Sends a message to the Discord webhook.
+
+    Args:
+        payload: The JSON payload to send to Discord.
+    """
+    if not settings.DISCORD_WEBHOOK_URL:
+        return
+
+    # Discord webhooks expect a 'content' key.
+    # We'll format the payload for better readability.
+    message = {
+        "content": "New POST request received:",
+        "embeds": [
+            {
+                "description": f"```json\n{json.dumps(payload, indent=2, ensure_ascii=False)}\n```",
+                "color": 5814783  # A nice blue color
+            }
+        ]
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.post(settings.DISCORD_WEBHOOK_URL, json=message)
+        except httpx.RequestError as e:
+            # In a real app, you'd want to log this error.
+            print(f"Error sending Discord webhook: {e}")


### PR DESCRIPTION
## 概述

加上了只要使用者發出POST request 時，就會在DC頻道傳送訊息的功能

## 變更內容

<!-- 列出主要的程式碼變更 -->

- 新增了  send_to_discord service，並在main.py上新增相關攔截POST request 的設定，同時也有考慮到有可能某些POST api不需要被攔截，可以使用exclude去篩選掉
- 新增了 config.py的DISCORD_WEBHOOK_URL設定
- 新增了 send_to_discord這個method的markdown文件，供各位開發者參考(gemini生成的，之後會更新成中文) 

## 測試方式

<!-- 說明如何測試這些變更 -->

1. 啟動開發伺服器
2. 前往 `/docs` 測試新的 API endpoint
3. 驗證回應格式是否正確

## 相關 Issue

Refs # https://www.notion.so/Discord-notify-for-human_resources-supplies-28bf457cb4288089841fc2b8b3fabd12?source=copy_link


## 截圖
/human_resources 
<img width="1367" height="520" alt="image" src="https://github.com/user-attachments/assets/05db1980-d983-4ca6-a184-82cd160fab09" />
/supplies
<img width="1370" height="331" alt="image" src="https://github.com/user-attachments/assets/6341501d-8d82-4c50-a0d5-1dbbe796d96d" />


## Checklist

- [ ] 程式碼遵循專案規範
- [x] 已新增/更新必要的測試(已讓gemini進行多次測試，但相關發送至discord的訊息格式可能要討論一下)
- [ ] 已更新相關文件
- [x] CI 檢查全部通過
- [x] 已在本地測試過
- [x] Commit 訊息符合 Conventional Commits 規範
