### PR TITLE
feat(env): add Discord webhook URL support

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -70,12 +70,13 @@ jobs:
           API_KEY_LIST: ${{ secrets.ALLOW_MODIFY_API_KEY_LIST }}
           LINE_CLIENT_ID: ${{ secrets.LINE_CLIENT_ID }}
           LINE_CLIENT_SECRET: ${{ secrets.LINE_CLIENT_SECRET }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           host: ${{ secrets.VM_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: 22
-          envs: ENVIRONMENT,DB_PASS,API_KEY_LIST, LINE_CLIENT_ID, LINE_CLIENT_SECRET
+          envs: ENVIRONMENT,DB_PASS,API_KEY_LIST,LINE_CLIENT_ID,LINE_CLIENT_SECRET,DISCORD_WEBHOOK_URL
           script: |
             cd /home/deploy/api-server
             ./deploy.sh ${{ needs.init.outputs.version }}

--- a/guanfu_backend/.env.example
+++ b/guanfu_backend/.env.example
@@ -67,6 +67,15 @@ LINE_CLIENT_SECRET=""
 # 新的實作中，redirect_uri 由前端在呼叫 /line/authorize API 時提供
 # 此設定保留以向下相容，但不再使用
 LINE_REDIRECT_URI=""
+
+# ----------------------------------------------------------------------------
+# Discord Webhook 設定（選用）
+# ----------------------------------------------------------------------------
+# 若需啟用 Discord 通知功能，請填入 Webhook URL
+# 取得方式：Discord 伺服器設定 > 整合 > Webhook > 建立 Webhook
+#
+# Discord Webhook URL（從 Discord 伺服器設定中取得）
+DISCORD_WEBHOOK_URL=""
 #
 # 本地開發模式（僅啟動資料庫容器，後端在本機執行）：使用 'localhost' 作為 host
 # DATABASE_URL=postgresql://guangfu_user:guangfu_dev_pass_2024@localhost:5432/guangfu

--- a/guanfu_backend/setup-env.sh
+++ b/guanfu_backend/setup-env.sh
@@ -4,6 +4,7 @@
 #   ENVIRONMENT=dev DB_PASS=xxx API_KEY_LIST=key1,key2 \
 #   LINE_CLIENT_ID=your_line_client_id \
 #   LINE_CLIENT_SECRET=your_line_client_secret \
+#   DISCORD_WEBHOOK_URL=your_discord_webhook_url \
 #   ./setup-env.sh
 #
 # Note: LINE_REDIRECT_URI 已棄用，現在由前端在 API 請求中提供
@@ -22,6 +23,9 @@ LINE_CLIENT_SECRET=${LINE_CLIENT_SECRET:-""}
 # LINE_REDIRECT_URI (DEPRECATED: 現在由前端在 /line/authorize 請求中提供)
 # 保留此設定以向下相容，但新的實作不再使用環境變數中的值
 LINE_REDIRECT_URI=${LINE_REDIRECT_URI:-""}
+
+# Discord Webhook parameters
+DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:-""}
 
 # Database settings
 DB_USER="guangfu"
@@ -78,6 +82,11 @@ DATABASE_URL=${DATABASE_URL}
 LINE_CLIENT_ID=${LINE_CLIENT_ID}
 LINE_CLIENT_SECRET=${LINE_CLIENT_SECRET}
 LINE_REDIRECT_URI=${LINE_REDIRECT_URI}
+
+# ----------------------------------------------------------------------------
+# Discord Webhook Settings
+# ----------------------------------------------------------------------------
+DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
 EOF
 
 # Verify .env file was created


### PR DESCRIPTION
- Add DISCORD_WEBHOOK_URL to environment setup and deployment workflow.
- Update .env.example and setup-env.sh to document and export the new variable.
- Extend CI/CD workflow to pass the Discord webhook secret for notification integration.