### PR TITLE
fix(crud): correct timestamp type for Supply created_at/updated_at fields

### DIFF
--- a/guanfu_backend/src/crud.py
+++ b/guanfu_backend/src/crud.py
@@ -159,14 +159,14 @@ def create_supply_with_items(db: Session, obj_in: SupplyCreate) -> models.Supply
         supply_data_raw = obj_in.model_dump(exclude={"supplies"}, exclude_unset=True)
         supply_data = normalize_payload_dict(supply_data_raw)  # Enum to value
 
-        # 設置必填的時間欄位（Supply 使用 bigint 存儲時間戳）
-        now_timestamp = int(datetime.now(timezone.utc).timestamp())
+        # 設置必填的時間欄位（Supply 使用 DateTime 存儲時間）
+        now = datetime.now(timezone.utc)
         db_supply = models.Supply(
             **supply_data,
             valid_pin=generate_pin(),
             spam_warn=False,
-            created_at=now_timestamp,
-            updated_at=now_timestamp
+            created_at=now,
+            updated_at=now
         )
         db.add(db_supply)
         db.flush()  # 先拿到 db_supply.id 供 item 關聯


### PR DESCRIPTION
## 問題描述 (Problem Description)

建立供應單時發生資料庫類型不符錯誤：

```
column "created_at" is of type timestamp with time zone but expression is of type integer
```

當使用 `POST /supplies` endpoint 建立供應單時，PostgreSQL 回報類型錯誤。

## 根本原因 (Root Cause)

在 `src/models.py:241-242` 中，`Supply` 模型定義：
```python
created_at = Column(DateTime(timezone=True), nullable=False, ...)
updated_at = Column(DateTime(timezone=True), nullable=False, ...)
```

但在 `src/crud.py:162-169` 中，程式碼傳入的是整數型態的 Unix timestamp：
```python
now_timestamp = int(datetime.now(timezone.utc).timestamp())
db_supply = models.Supply(
    created_at=now_timestamp,  # ← 整數 (1761020460)
    updated_at=now_timestamp   # ← 整數 (1761020460)
)
```

## 解決方案 (Solution)

將時間戳記從整數改為 datetime 物件：
- 從 `int(datetime.now().timestamp())` 改為 `datetime.now(timezone.utc)`
- 更新註解以反映正確使用 DateTime 而非 bigint
- 與 `src/models.py` 中的模型定義保持一致

## 測試 (Test)

修復後可以正常建立供應單：
```bash
curl -X 'POST' \
  'http://localhost:8080/supplies' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{"name":"後端","address":"線上","phone":"","supplies":{"tag":"其他","name":"測試","unit":"人","received_count":0,"total_number":1}}'
```

## 影響範圍 (Impact)

- ✅ 修復供應單建立功能
- ✅ 與資料庫 schema 保持一致
- ✅ 不影響其他功能（`pii_date` 仍使用 BigInteger，保持不變）

🤖 Generated with [Claude Code](https://claude.com/claude-code)